### PR TITLE
Fix RegEx Exclusion and always exclude metric kafka.common.AppInfo.Version

### DIFF
--- a/src/main/java/com/criteo/kafka/KafkaGraphiteMetricsReporter.java
+++ b/src/main/java/com/criteo/kafka/KafkaGraphiteMetricsReporter.java
@@ -47,7 +47,7 @@ public class KafkaGraphiteMetricsReporter implements KafkaMetricsReporter, Kafka
     private String graphiteHost = GRAPHITE_DEFAULT_HOST;
     private int graphitePort = GRAPHITE_DEFAULT_PORT;
     private String graphiteGroupPrefix = GRAPHITE_DEFAULT_PREFIX;
-    private MetricPredicate predicate = MetricPredicate.ALL;
+    private MetricPredicate predicate = new RegexMetricPredicate();
 
     @Override
     public String getMBeanName() {

--- a/src/main/java/com/criteo/kafka/RegexMetricPredicate.java
+++ b/src/main/java/com/criteo/kafka/RegexMetricPredicate.java
@@ -26,11 +26,21 @@ import com.yammer.metrics.core.MetricPredicate;
 
 /**
  * Implementation of {@link MetricPredicate} which will <b>exclude<b/> metrics if they match
- * the given regular expression.
+ * the given regular expression.<br>
+ * It will also exclude the {@code kafka.common.AppInfo.Version} metric which causes warnings in graphite because of the invalid value.
  */
 class RegexMetricPredicate implements MetricPredicate {
 
+    private static final Pattern APPVERSION_PATTERN = Pattern.compile("kafka.common.AppInfo.Version");
+
     private final Pattern pattern;
+
+    /**
+     * Default constructor which just excludes the metric containing Kafka's version
+     */
+    public RegexMetricPredicate() {
+        pattern = null;
+    }
 
     /**
      * Constructor.
@@ -43,7 +53,14 @@ class RegexMetricPredicate implements MetricPredicate {
 
     @Override
     public boolean matches(MetricName name, Metric metric) {
-        return !pattern.matcher(String.format("%s.%s.%s", name.getGroup(), name.getType(), name.getName())).matches();
+        String metricName = String.format("%s.%s.%s", name.getGroup(), name.getType(), name.getName());
+        boolean isNotVersionMetric = !APPVERSION_PATTERN.matcher(metricName).matches();
+
+        if (isNotVersionMetric && pattern != null) {
+            return !pattern.matcher(metricName).matches();
+        } else {
+            return isNotVersionMetric;
+        }
     }
 
 }

--- a/src/main/java/com/criteo/kafka/RegexMetricPredicate.java
+++ b/src/main/java/com/criteo/kafka/RegexMetricPredicate.java
@@ -43,7 +43,7 @@ class RegexMetricPredicate implements MetricPredicate {
 
     @Override
     public boolean matches(MetricName name, Metric metric) {
-        return !pattern.matcher(name.getName()).matches();
+        return !pattern.matcher(String.format("%s.%s.%s", name.getGroup(), name.getType(), name.getName())).matches();
     }
 
 }

--- a/src/test/java/com/criteo/kafka/KafkaGraphiteMetricsReporterTest.java
+++ b/src/test/java/com/criteo/kafka/KafkaGraphiteMetricsReporterTest.java
@@ -18,12 +18,13 @@
 
 package com.criteo.kafka;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+
+import java.util.Properties;
+
 import org.junit.Test;
 
 import kafka.utils.VerifiableProperties;
-
-import java.util.Properties;
 
 public class KafkaGraphiteMetricsReporterTest {
 
@@ -43,7 +44,7 @@ public class KafkaGraphiteMetricsReporterTest {
 
         reporter.init(new VerifiableProperties(properties));
 
-        reporter.startReporter(1l);
+        reporter.startReporter(1L);
         reporter.stopReporter();
     }
 

--- a/src/test/java/com/criteo/kafka/RegexMetricPredicateTest.java
+++ b/src/test/java/com/criteo/kafka/RegexMetricPredicateTest.java
@@ -34,7 +34,7 @@ public class RegexMetricPredicateTest {
 
     @Test
     public void matches() {
-        MetricPredicate predicate = new RegexMetricPredicate("foobar.*");
+        MetricPredicate predicate = new RegexMetricPredicate("group.type.foobar.*");
 
         assertFalse(predicate.matches(buildMetricName("foobar.count"), null));
         assertFalse(predicate.matches(buildMetricName("foobar.rate"), null));
@@ -46,6 +46,7 @@ public class RegexMetricPredicateTest {
     }
 
     private MetricName buildMetricName(String name) {
-        return new  MetricName("group", "type", name, "scope", "mBeanName");
+        return new MetricName("group", "type", name, "scope", "mBeanName");
     }
+
 }

--- a/src/test/java/com/criteo/kafka/RegexMetricPredicateTest.java
+++ b/src/test/java/com/criteo/kafka/RegexMetricPredicateTest.java
@@ -33,6 +33,22 @@ public class RegexMetricPredicateTest {
          new RegexMetricPredicate(null);
     }
 
+    @Test
+    public void alwaysExcludeAppVersion_NoRegEx() {
+        MetricPredicate predicate = new RegexMetricPredicate();
+
+        assertFalse(predicate.matches(new MetricName("kafka.common", "AppInfo", "Version", "scope", "mBeanName"), null));
+        assertTrue(predicate.matches(new MetricName("kafka.common", "AppInfo", "SomethingElse", "scope", "mBeanName"), null));
+    }
+
+    @Test
+    public void alwaysExcludeAppVersion_WithRegEx() {
+        MetricPredicate predicate = new RegexMetricPredicate("group.type.foobar.*");
+
+        assertFalse(predicate.matches(new MetricName("kafka.common", "AppInfo", "Version", "scope", "mBeanName"), null));
+        assertTrue(predicate.matches(new MetricName("kafka.common", "AppInfo", "SomethingElse", "scope", "mBeanName"), null));
+     }
+
 
     @Test
     public void matches() {

--- a/src/test/java/com/criteo/kafka/RegexMetricPredicateTest.java
+++ b/src/test/java/com/criteo/kafka/RegexMetricPredicateTest.java
@@ -18,7 +18,9 @@
 
 package com.criteo.kafka;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import org.junit.Test;
 
 import com.yammer.metrics.core.MetricName;


### PR DESCRIPTION
  because the version of kafka is reported invalid by the reporter and cause something like this in the kafka logs:
    invalid line (kafka.common.AppInfo.Version.value 0.8.2.0 1450277961) received from client XX.XX.XX.XX:XXXXX, ignoring
