### PR TITLE
Support for scope in the regex filtering.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <groupId>de.emetriq.kafka</groupId>
   <artifactId>kafka-graphite</artifactId>
   <packaging>jar</packaging>
-  <version>1.0.2</version>
+  <version>1.0.3-SNAPSHOT</version>
   <name>Kafka metrics output to Graphite</name>
   <url>https://github.com/emetriq/kafka-graphite/</url>
 

--- a/src/main/java/com/criteo/kafka/FilterMetricPredicate.java
+++ b/src/main/java/com/criteo/kafka/FilterMetricPredicate.java
@@ -63,7 +63,8 @@ class FilterMetricPredicate implements MetricPredicate {
 
     @Override
     public boolean matches(MetricName name, Metric metric) {
-        String metricName = String.format("%s.%s.%s", name.getGroup(), name.getType(), name.getName());
+        String metricName = sanitizeName(name);
+
         boolean isVersionMetric = APPVERSION_PATTERN.matcher(metricName).matches();
 
         if (isVersionMetric || cleanInvalidGauge(name, metric, metricName)) {
@@ -92,6 +93,22 @@ class FilterMetricPredicate implements MetricPredicate {
             LOGGER.error("Caught an Exception while processing metric " + metricName, ex);
         }
         return false;
+    }
+
+
+    // same as in GraphiteReporter
+    // the scope is needed to support for example the metrics like: kafka.server.BrokerTopicMetrics.topic.TOPICNAME.BytesOutPerSec
+    private String sanitizeName(MetricName name) {
+        final StringBuilder sb = new StringBuilder()
+                .append(name.getGroup())
+                .append('.')
+                .append(name.getType())
+                .append('.');
+        if (name.hasScope()) {
+            sb.append(name.getScope())
+                    .append('.');
+        }
+        return sb.append(name.getName()).toString();
     }
 
 }

--- a/src/test/java/com/criteo/kafka/FilterMetricPredicateTest.java
+++ b/src/test/java/com/criteo/kafka/FilterMetricPredicateTest.java
@@ -60,16 +60,16 @@ public class FilterMetricPredicateTest {
     public void alwaysExcludeAppVersion_NoRegEx() {
         MetricPredicate predicate = new FilterMetricPredicate();
 
-        assertFalse(predicate.matches(new MetricName("kafka.common", "AppInfo", "Version", "scope", "mBeanName"), metricMock));
-        assertTrue(predicate.matches(new MetricName("kafka.common", "AppInfo", "SomethingElse", "scope", "mBeanName"), metricMock));
+        assertFalse(predicate.matches(new MetricName("kafka.common", "AppInfo", "Version", null, "mBeanName"), metricMock));
+        assertTrue(predicate.matches(new MetricName("kafka.common", "AppInfo", "SomethingElse", null, "mBeanName"), metricMock));
     }
 
     @Test
     public void alwaysExcludeAppVersion_WithRegEx() {
         MetricPredicate predicate = new FilterMetricPredicate("group.type.foobar.*");
 
-        assertFalse(predicate.matches(new MetricName("kafka.common", "AppInfo", "Version", "scope", "mBeanName"), metricMock));
-        assertTrue(predicate.matches(new MetricName("kafka.common", "AppInfo", "SomethingElse", "scope", "mBeanName"), metricMock));
+        assertFalse(predicate.matches(new MetricName("kafka.common", "AppInfo", "Version", null, "mBeanName"), metricMock));
+        assertTrue(predicate.matches(new MetricName("kafka.common", "AppInfo", "SomethingElse", null, "mBeanName"), metricMock));
      }
 
     @Test
@@ -122,10 +122,9 @@ public class FilterMetricPredicateTest {
         assertEquals(Metrics.defaultRegistry().allMetrics().get(metricName), gauge);
     }
 
-
     @Test
     public void matches() {
-        MetricPredicate predicate = new FilterMetricPredicate("group.type.foobar.*");
+        MetricPredicate predicate = new FilterMetricPredicate("group.type.scope.foobar.*");
 
         assertFalse(predicate.matches(buildMetricName("foobar.count"), metricMock));
         assertFalse(predicate.matches(buildMetricName("foobar.rate"), metricMock));


### PR DESCRIPTION
This is needed to support the filtering of metrics like kafka.server.BrokerTopicMetrics.topic.TOPICNAME.BytesOutPerSec when you only want
to filter the reporting for some topics (for example temporary topics)
